### PR TITLE
Fixed Language List Alphabetization

### DIFF
--- a/generate_wiki/generate_wiki.py
+++ b/generate_wiki/generate_wiki.py
@@ -27,7 +27,7 @@ class Repo:
 
     def get_languages_by_letter(self, letter):
         language_list = [language for language in self.languages if language.name.startswith(letter)]
-        return language_list
+        return sorted(language_list, key = lambda s: s.casefold())
 
 
 class Language:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="generate_wiki",
-    version="1.0.3",
+    version="1.0.4",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
     description="A wiki generation package for the Sample Programs repo",


### PR DESCRIPTION
Previously, I had fixed a bug that caused the list of languages by letter not be out of order. Now, that bug is appearing in the list of languages on each letter page. This should fix that issue.